### PR TITLE
Remove magic numbers

### DIFF
--- a/src/Constants.js
+++ b/src/Constants.js
@@ -1,0 +1,3 @@
+export const SMALL_SCREEN = 650;
+export const CAROUSEL_TRANSITION_TIME = 2000;
+export const CAROUSEL_INTERVAL = 5000;

--- a/src/pages/About.jsx
+++ b/src/pages/About.jsx
@@ -1,7 +1,27 @@
 import React from "react";
 import ProfilePic from "../assets/profile-pic.jpg";
+import { SMALL_SCREEN } from "../Constants";
 
 function About() {
+  /* Keeps track of the window dimensions.  Updates when window resizes */
+  const [dimensions, setDimensions] = React.useState({
+    height: window.innerHeight,
+    width: window.innerWidth,
+  });
+  React.useEffect(() => {
+    function handleResize() {
+      setDimensions({
+        height: window.innerHeight,
+        width: window.innerWidth,
+      });
+    }
+
+    window.addEventListener("resize", handleResize);
+    return (_) => {
+      window.removeEventListener("resize", handleResize);
+    };
+  });
+
   return (
     <div className="content-container">
       <img
@@ -11,12 +31,25 @@ function About() {
       ></img>
       <div className="fade left">
         <h1>About</h1>
-        <p>
-          I am a problem solver that loves to program. This has lead to a deep
-          interest in robotics and a passion for coding and algorithms. I also
-          enjoy design and I am good at coming up with creative solutions and
-          work well in a team.
-        </p>
+        {dimensions.width < SMALL_SCREEN ? (
+          <>
+            <p>
+              I am a problem solver that loves to program. This has lead to a
+              deep interest in robotics and a passion for coding and algorithms.{" "}
+            </p>
+            <p>
+              I also enjoy design and I am good at coming up with creative
+              solutions and work well in a team.
+            </p>
+          </>
+        ) : (
+          <p>
+            I am a problem solver that loves to program. This has lead to a deep
+            interest in robotics and a passion for coding and algorithms. I also
+            enjoy design and I am good at coming up with creative solutions and
+            work well in a team.
+          </p>
+        )}
         <p>
           I'm currently doing Computer Systems Engineering, conjoint with
           Science; Logic and Computation. During this I'm learning a range of

--- a/src/pages/Navigation.jsx
+++ b/src/pages/Navigation.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import { Link, withRouter } from "react-router-dom";
+import { SMALL_SCREEN } from "../Constants";
 
 function Navigation(props) {
   const [dropdownOpen, setdropdownOpen] = useState(false);
@@ -15,7 +16,7 @@ function Navigation(props) {
         height: window.innerHeight,
         width: window.innerWidth,
       });
-      if (dimensions.width >= 600) {
+      if (dimensions.width >= SMALL_SCREEN) {
         setdropdownOpen(false);
       }
     }
@@ -34,7 +35,7 @@ function Navigation(props) {
             <Link to="/" onClick={() => setdropdownOpen(false)}>
               <li>Kimberley Evans-Parker</li>
             </Link>
-            {dimensions.width < 650 && (
+            {dimensions.width < SMALL_SCREEN && (
               <div
                 className={`navbar-rightside`}
                 onClick={() => setdropdownOpen(!dropdownOpen)}
@@ -49,7 +50,7 @@ function Navigation(props) {
               </div>
             )}
           </ul>
-          {(dropdownOpen || dimensions.width >= 650) && (
+          {(dropdownOpen || dimensions.width >= SMALL_SCREEN) && (
             <div
               className={`navbar-rightside ${dropdownOpen && "dropdown-open"}`}
             >

--- a/src/pages/components/ContentItem.jsx
+++ b/src/pages/components/ContentItem.jsx
@@ -4,6 +4,12 @@ import Grid from "@material-ui/core/Grid";
 import { Carousel } from "react-responsive-carousel";
 import "react-responsive-carousel/lib/styles/carousel.min.css";
 
+import {
+  SMALL_SCREEN,
+  CAROUSEL_TRANSITION_TIME,
+  CAROUSEL_INTERVAL,
+} from "../../Constants";
+
 function ContentItem(props) {
   /* Keeps track of the window dimensions.  Updates when window resizes */
   const [dimensions, setDimensions] = React.useState({
@@ -26,12 +32,14 @@ function ContentItem(props) {
 
   return (
     <Grid container spacing={3}>
-      {(!props.imgOnLeft || dimensions.width < 600) && (
+      {(!props.imgOnLeft || dimensions.width < SMALL_SCREEN) && (
         <Grid
           item
           xs
           className={
-            props.images && dimensions.width >= 600 ? "fade right" : "fade left"
+            props.images && dimensions.width >= SMALL_SCREEN
+              ? "fade right"
+              : "fade left"
           }
           style={{
             webkitAnimationDelay: props.animationDelay,
@@ -55,7 +63,7 @@ function ContentItem(props) {
           sm={6}
           md={4}
           className={
-            props.imgOnLeft && dimensions.width >= 600
+            props.imgOnLeft && dimensions.width >= SMALL_SCREEN
               ? "fade right"
               : "fade left"
           }
@@ -72,8 +80,8 @@ function ContentItem(props) {
             showIndicators={props.images.length > 1}
             showStatus={props.images.length > 1}
             showThumbs={false}
-            transitionTime={1500}
-            interval={4000}
+            transitionTime={CAROUSEL_TRANSITION_TIME}
+            interval={CAROUSEL_INTERVAL}
             infiniteLoop={true}
           >
             {props.images.map((image) => {
@@ -89,7 +97,7 @@ function ContentItem(props) {
           </Carousel>
         </Grid>
       )}
-      {props.imgOnLeft && dimensions.width >= 600 && (
+      {props.imgOnLeft && dimensions.width >= SMALL_SCREEN && (
         <Grid
           item
           xs


### PR DESCRIPTION
## GitHub Issue Solved:

closes #49 <!--Reference the number of the solved issue-->

## Current behaviour
The code uses a number of magic numbers
The About page has empty space when viewed on a small screen
<!--Please describe the current behaviour-->

## Changed behaviour
A `Constants.js` page has been created with the constants to replace the magic numbers
The About page realigns on a small screen to accommodate the available space better
<!--Please describe the behaviour after the PR has been merged-->

## Notes
Current constants:
`SMALL_SCREEN`
`CAROUSEL_TRANSITION_TIME`
`CAROUSEL_INTERVAL`
<!--You may add screenshots or other information if you think it's relevant-->
