### PR TITLE
Adjust navbar sizing

### DIFF
--- a/src/Constants.js
+++ b/src/Constants.js
@@ -1,3 +1,3 @@
-export const SMALL_SCREEN = 650;
+export const SMALL_SCREEN = 750;
 export const CAROUSEL_TRANSITION_TIME = 2000;
 export const CAROUSEL_INTERVAL = 5000;

--- a/src/index.css
+++ b/src/index.css
@@ -127,6 +127,10 @@ button:hover {
 }
 
 /* ----------------------------- nav ----------------------------- */
+.fa-github {
+  font-size: 24px;
+  top: 5px;
+}
 
 nav {
   position: fixed;


### PR DESCRIPTION
## GitHub Issue Solved:

closes #59  <!--Reference the number of the solved issue-->

## Current behaviour
GitHub icon looks too small
At a certain screen size, the navbar goes over 2 lines
<!--Please describe the current behaviour-->

## Changed behaviour
GitHub icon is bigger
Navbar is only over 1 line and switches to a dropdown before going to two lines
<!--Please describe the behaviour after the PR has been merged-->
