### PR TITLE
Center image above text on small screen

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -107,14 +107,22 @@ button:hover {
 }
 
 .profile-pic {
-  width: 100%;
   border-radius: 50%;
   box-shadow: 10px 10px 20px var(--shadow-colour);
-  width: 30vw;
+  width: 50vw;
   max-width: 200px;
-  float: left;
   margin-right: 30px;
   margin-bottom: 20px;
+}
+
+.float-left {
+  float: left;
+}
+
+.center-2 {
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .content-container {

--- a/src/pages/About.jsx
+++ b/src/pages/About.jsx
@@ -26,30 +26,19 @@ function About() {
     <div className="content-container">
       <img
         src={ProfilePic}
-        className="profile-pic fade right"
+        className={`profile-pic fade right ${
+          dimensions.width < SMALL_SCREEN ? "center-2" : "float-left"
+        }`}
         alt="Profile"
       ></img>
       <div className="fade left">
         <h1>About</h1>
-        {dimensions.width < SMALL_SCREEN ? (
-          <>
-            <p>
-              I am a problem solver that loves to program. This has lead to a
-              deep interest in robotics and a passion for coding and algorithms.{" "}
-            </p>
-            <p>
-              I also enjoy design and I am good at coming up with creative
-              solutions and work well in a team.
-            </p>
-          </>
-        ) : (
-          <p>
-            I am a problem solver that loves to program. This has lead to a deep
-            interest in robotics and a passion for coding and algorithms. I also
-            enjoy design and I am good at coming up with creative solutions and
-            work well in a team.
-          </p>
-        )}
+        <p>
+          I am a problem solver that loves to program. This has lead to a deep
+          interest in robotics and a passion for coding and algorithms. I also
+          enjoy design and I am good at coming up with creative solutions and
+          work well in a team.
+        </p>
         <p>
           I'm currently doing Computer Systems Engineering, conjoint with
           Science; Logic and Computation. During this I'm learning a range of


### PR DESCRIPTION
## GitHub Issue Solved:

closes #58  <!--Reference the number of the solved issue-->

## Current behaviour
On small screens, the About page text wraps around the profile picture.
<!--Please describe the current behaviour-->

## Changed behaviour
On small screens, the profile picture is centered above the About page text wraps.
<!--Please describe the behaviour after the PR has been merged-->

## Notes
On a bigger screen, the look is the same as previously
<!--You may add screenshots or other information if you think it's relevant-->
