### PR TITLE
Fix cosplay heading

### DIFF
--- a/src/pages/hobbies/Cosplays.tsx
+++ b/src/pages/hobbies/Cosplays.tsx
@@ -9,7 +9,7 @@ export const Cosplays = () => {
   return (
     <div className="content-container experience-container">
       <div className="fade left">
-        <h1>Lego</h1>
+        <h1>Cosplays</h1>
         <p>
           I enjoy sewing, making costumes and looking cool in them ^.^ I often
           design, sew and create my dresses from scratch. Some of my favourite


### PR DESCRIPTION
## GitHub Issue Solved:

closes #325  <!--Reference the number of the solved issue-->

## Changed behaviour
Cosplay heading is now Cosplays instead of Lego
<!--Please describe the behaviour after the PR has been merged-->

## Notes

<!--You may add screenshots or other information if you think it's relevant-->
