### PR TITLE
carousel height not 100vh

### DIFF
--- a/src/pages/components/modal/modal.css
+++ b/src/pages/components/modal/modal.css
@@ -29,7 +29,7 @@
   max-height: 100vh;
 }
 
-.carousel .slide {
+.modal-content .carousel .slide {
   display: flex;
   justify-content: center;
   height: 100vh;


### PR DESCRIPTION
## GitHub Issue Solved:

closes #430  <!--Reference the number of the solved issue-->

## Changed behaviour
Carousel height not 100vh unless it's in a modal
<!--Please describe the behaviour after the PR has been merged-->
