### PR TITLE
Remove navbar-container-smallscreen

### DIFF
--- a/src/pages/navigation/SubNavbar.tsx
+++ b/src/pages/navigation/SubNavbar.tsx
@@ -1,5 +1,3 @@
-import React from "react"
-import { SMALL_SCREEN } from "../../helpers/Constants";
 import { SubNavbarLink } from "./SubNavbarLink";
 
 interface SubNavbarProps {
@@ -8,33 +6,10 @@ interface SubNavbarProps {
 }
 
 export const SubNavbar = ({ headings, section }: SubNavbarProps) => {
-  /* Keeps track of the window dimensions.  Updates when window resizes */
-  const [dimensions, setDimensions] = React.useState({
-    height: window.innerHeight,
-    width: window.innerWidth,
-  });
-  React.useEffect(() => {
-    const handleResize = () => {
-      setDimensions({
-        height: window.innerHeight,
-        width: window.innerWidth,
-      });
-    }
-
-    window.addEventListener("resize", handleResize);
-    return () => {
-      window.removeEventListener("resize", handleResize);
-    };
-  });
-
   return (
     <nav className="nav2 slide-in">
       <div
-        className={`nav2-container ${
-          dimensions.width >= SMALL_SCREEN
-            ? "navbar-container"
-            : "navbar-container-smallscreen"
-        }`}
+        className="nav2-container navbar-container"
       >
         <ul>
           {headings.map((heading) => {


### PR DESCRIPTION
## GitHub Issue Solved:

closes #467 <!--Reference the number of the solved issue-->

## Changed behaviour
removed references to navbar-container-smallscreen
Removed js useeffect that's also now no longer used
<!--Please describe the behaviour after the PR has been merged-->

## Notes

<!--You may add screenshots or other information if you think it's relevant-->
