### PR TITLE
dropdown appear in front of other content

### DIFF
--- a/src/pages/components/toolbar/tool-bar.css
+++ b/src/pages/components/toolbar/tool-bar.css
@@ -15,4 +15,5 @@
   display: flex;
   align-items: center;
   gap: 10px;
+  z-index: 10;
 }


### PR DESCRIPTION
## GitHub Issue Solved:

closes #375  <!--Reference the number of the solved issue-->

## Changed behaviour
filter dropdown appears in front of the content
<!--Please describe the behaviour after the PR has been merged-->
